### PR TITLE
Containers should be immutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,13 @@ Here's an example `chatops_deployer.yml` :
 expose:
   web: [3000]
 
-# `commands` is a hash in the format <service>: {first_run: <array of commands>, next_runs: <array of commands>}
-# Commands under first_run are run only once, when the container is run for the first time.
-# Commands under next_runs are for all subsequent deployments in the same container, but not
-# run on the first deployment.
+# `commands` is a list of commands that should be run inside a service container
+# before all systems are go.
 # Commands are run in the same order as they appear in the list.
 commands:
-  web:
-    first_run:
-      - bundle exec rake db:create
-      - bundle exec rake db:schema:load
-    next_runs:
-      - bundle exec rake db:migrate
+  - [db, "./setup_script_in_container"]
+  - [web, "bundle exec rake db:create"]
+  - [web, "bundle exec rake db:schema:load"]
 
 # `copy` is an array of strings in the format "<source>:<destination>"
 # If source begins with './' , the source file is searched from the root of the cloned

--- a/lib/chatops_deployer/project.rb
+++ b/lib/chatops_deployer/project.rb
@@ -25,18 +25,14 @@ module ChatopsDeployer
 
     def fetch_repo
       logger.info "Fetching #{@repository}:#{@branch}"
-      if Dir.entries('.').size == 2
-        logger.info "Directory not found. Cloning"
-        git_clone = Command.run(command: ['git', 'clone', "--branch=#{@branch}", '--depth=1', @repository, '.'], logger: logger)
-        unless git_clone.success?
-          raise_error("Cannot clone git repository: #{@repository}, branch: #{@branch}")
-        end
-      else
-        logger.info "Directory exists. Fetching"
-        git_pull = Command.run(command: ['git', 'pull', 'origin', @branch], logger: logger)
-        unless git_pull.success?
-          raise_error("Cannot pull git repository: #{@repository}, branch: #{@branch}")
-        end
+      unless Dir.entries('.').size == 2
+        logger.info "Branch already cloned. Deleting everything before cloning again"
+        FileUtils.rm_rf '.'
+      end
+      logger.info "Cloning branch #{@repository}:#{@branch}"
+      git_clone = Command.run(command: ['git', 'clone', "--branch=#{@branch}", '--depth=1', @repository, '.'], logger: logger)
+      unless git_clone.success?
+        raise_error("Cannot clone git repository: #{@repository}, branch: #{@branch}")
       end
     end
 

--- a/spec/chatops_deployer/container_spec.rb
+++ b/spec/chatops_deployer/container_spec.rb
@@ -23,12 +23,8 @@ describe ChatopsDeployer::Container do
         expose:
           web: [3000]
         commands:
-          web:
-            first_run:
-              - bundle exec rake db:create
-              - bundle exec rake db:schema:load
-            next_runs:
-              - bundle exec rake db:migrate
+          - [web, "bundle exec rake db:create"]
+          - [web, "bundle exec rake db:schema:load"]
       EOM
     end
   end
@@ -81,26 +77,6 @@ describe ChatopsDeployer::Container do
       expect(ENV['KEY1']).to eql 'VALUE1'
       expect(ENV['KEY2']).to eql 'VALUE2'
       expect(container.urls).to eql({'web' => [['1.2.3.4','3001']]})
-    end
-
-    context 'next runs' do
-      it 'runs the next_runs commands' do
-        expect(ChatopsDeployer::Command).to receive(:run)
-          .with(command: 'docker-machine url fake_sha1', logger: container.logger)
-          .and_return double(:command, success?: true)
-        expect(ChatopsDeployer::Command).to receive(:run)
-          .with(command: 'docker-compose run web bundle exec rake db:migrate', logger: container.logger)
-          .and_return double(:command, success?: true)
-        expect(ChatopsDeployer::Command).to receive(:run)
-          .with(command: 'docker-compose restart', logger: container.logger)
-          .and_return double(:command, success?: true)
-
-        container.build
-
-        expect(ENV['KEY1']).to eql 'VALUE1'
-        expect(ENV['KEY2']).to eql 'VALUE2'
-        expect(container.urls).to eql({'web' => [['1.2.3.4','3001']]})
-      end
     end
   end
 end

--- a/spec/chatops_deployer/project_spec.rb
+++ b/spec/chatops_deployer/project_spec.rb
@@ -39,17 +39,18 @@ describe ChatopsDeployer::Project do
     end
 
     context 'when directory is not empty' do
-      it 'pulls changes from remote branch' do
+      it 'removes everything and clones again' do
         dummy_file = File.join project.branch_directory, 'dummy'
         File.open(dummy_file, 'w')
 
-        Dir.chdir project.branch_directory
-        git_command = ["git", "pull", "origin", "branch"]
+        git_command = ["git", "clone", "--branch=branch", "--depth=1", repo, "."]
         expect(ChatopsDeployer::Command).to receive(:run)
           .with(command: git_command, logger: project.logger) do
           double(:command, success?: true)
         end
+        Dir.chdir project.branch_directory
         project.fetch_repo
+        expect(Dir.entries('.').size).to eql 2
       end
     end
 


### PR DESCRIPTION
Earlier, we had a concept of first and next runs. This commit changes
that to "first and only" run which means any subsequent deployment
should delete the stack and create it from scratch

Affected: `commands` option in chatops_deployer.yml