### PR TITLE
Fix homepage link in gemspec

### DIFF
--- a/chatops_deployer.gemspec
+++ b/chatops_deployer.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{An opinionated Chatops backend}
   spec.description   = %q{ChatopsDeployer deploys containerized services in isolated VMs and exposes public facing URLs}
-  spec.homepage      = "https://github.com/code-mancers/chatops-deployer"
+  spec.homepage      = "https://github.com/code-mancers/chatops_deployer"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
"chatops-deployer" with a hyphen gets redirected to https://github.com/code-mancers/flynn-deployer