### PR TITLE
Force docker image builds before running containers

### DIFF
--- a/lib/chatops_deployer/container.rb
+++ b/lib/chatops_deployer/container.rb
@@ -18,6 +18,7 @@ module ChatopsDeployer
 
     def build
       @config = @project.config
+      docker_compose_build
       docker_compose_run_commands
       docker_compose_up
     end
@@ -28,6 +29,12 @@ module ChatopsDeployer
     end
 
     private
+
+    def docker_compose_build
+      logger.info "Building images"
+      build_command = Command.run(command: ["docker-compose", "-p", @sha1, "build"], logger: logger)
+      raise_error("docker-compose -p #{@sha1} build failed") unless build_command.success?
+    end
 
     def docker_compose_run_commands
       logger.info "Running commands on containers"

--- a/spec/chatops_deployer/container_spec.rb
+++ b/spec/chatops_deployer/container_spec.rb
@@ -38,6 +38,9 @@ describe ChatopsDeployer::Container do
   describe '#build' do
     it 'uses docker-compose create the environment' do
       expect(ChatopsDeployer::Command).to receive(:run)
+        .with(command: ['docker-compose', '-p', 'fake_sha1', 'build'], logger: container.logger)
+        .and_return double(:command, success?: true)
+      expect(ChatopsDeployer::Command).to receive(:run)
         .with(command: ['docker-compose', '-p', 'fake_sha1', 'run', 'web', 'bundle', 'exec', 'rake', 'db:create'], logger: container.logger)
         .and_return double(:command, success?: true)
       expect(ChatopsDeployer::Command).to receive(:run)


### PR DESCRIPTION
This will ensure that none of the source code is cached
between deployments.